### PR TITLE
ML-4885: improve clean

### DIFF
--- a/src/main/java/gate/annotation/AnnotationSetImpl.java
+++ b/src/main/java/gate/annotation/AnnotationSetImpl.java
@@ -185,13 +185,13 @@ public class AnnotationSetImpl extends AbstractSet<Annotation> implements
   
   @Override
   public void clear() {
-    // while nullifying the indexes does clear the set it doesn't fire the
-    // appropriate events so use the Iterator based clear implementation in
-    // AbstractSet.clear() first and then reset the indexes
-    super.clear();
+
+    annotsById.values().forEach(annotation -> fireAnnotationRemoved(new AnnotationSetEvent(AnnotationSetImpl.this,
+            AnnotationSetEvent.ANNOTATION_REMOVED, getDocument(),
+            annotation)));
     
     //reset all the indexes to be sure everything has been cleared correctly
-    annotsById = new HashMap<Integer, Annotation>();
+    annotsById.clear();
     nodesByOffset = null;
     annotsByStartNode = null;
     annotsByType = null;
@@ -202,11 +202,11 @@ public class AnnotationSetImpl extends AbstractSet<Annotation> implements
    * This inner class serves as the return value from the iterator() method.
    */
   class AnnotationSetIterator implements Iterator<Annotation> {
-    private Iterator<Annotation> iter;
-    protected Annotation lastNext = null;
+    private Iterator<Map.Entry<Integer, Annotation>> iter;
+    protected Map.Entry<Integer, Annotation> lastNext = null;
 
     AnnotationSetIterator() {
-      iter = annotsById.values().iterator();
+      iter = annotsById.entrySet().iterator();
     }
 
     @Override
@@ -216,7 +216,8 @@ public class AnnotationSetImpl extends AbstractSet<Annotation> implements
 
     @Override
     public Annotation next() {
-      return (lastNext = iter.next());
+      lastNext = iter.next();
+      return lastNext.getValue();
     }
 
     @Override
@@ -228,14 +229,14 @@ public class AnnotationSetImpl extends AbstractSet<Annotation> implements
       if(lastNext == null) return;
 
       // remove from type index
-      removeFromTypeIndex(lastNext);
+      removeFromTypeIndex(lastNext.getValue());
       // remove from offset indices
-      removeFromOffsetIndex(lastNext);
+      removeFromOffsetIndex(lastNext.getValue());
       // that's the second way of removing annotations from a set
       // apart from calling remove() on the set itself
       fireAnnotationRemoved(new AnnotationSetEvent(AnnotationSetImpl.this,
               AnnotationSetEvent.ANNOTATION_REMOVED, getDocument(),
-              lastNext));
+              lastNext.getValue()));
     } // remove()
   }; // AnnotationSetIterator
 

--- a/src/main/java/gate/annotation/AnnotationSetImpl.java
+++ b/src/main/java/gate/annotation/AnnotationSetImpl.java
@@ -202,11 +202,11 @@ public class AnnotationSetImpl extends AbstractSet<Annotation> implements
    * This inner class serves as the return value from the iterator() method.
    */
   class AnnotationSetIterator implements Iterator<Annotation> {
-    private Iterator<Map.Entry<Integer, Annotation>> iter;
-    protected Map.Entry<Integer, Annotation> lastNext = null;
+    private Iterator<Annotation> iter;
+    protected Annotation lastNext = null;
 
     AnnotationSetIterator() {
-      iter = annotsById.entrySet().iterator();
+      iter = annotsById.values().iterator();
     }
 
     @Override
@@ -216,8 +216,7 @@ public class AnnotationSetImpl extends AbstractSet<Annotation> implements
 
     @Override
     public Annotation next() {
-      lastNext = iter.next();
-      return lastNext.getValue();
+      return (lastNext = iter.next());
     }
 
     @Override
@@ -229,14 +228,14 @@ public class AnnotationSetImpl extends AbstractSet<Annotation> implements
       if(lastNext == null) return;
 
       // remove from type index
-      removeFromTypeIndex(lastNext.getValue());
+      removeFromTypeIndex(lastNext);
       // remove from offset indices
-      removeFromOffsetIndex(lastNext.getValue());
+      removeFromOffsetIndex(lastNext);
       // that's the second way of removing annotations from a set
       // apart from calling remove() on the set itself
       fireAnnotationRemoved(new AnnotationSetEvent(AnnotationSetImpl.this,
               AnnotationSetEvent.ANNOTATION_REMOVED, getDocument(),
-              lastNext.getValue()));
+              lastNext));
     } // remove()
   }; // AnnotationSetIterator
 

--- a/src/main/java/gate/annotation/AnnotationSetImpl.java
+++ b/src/main/java/gate/annotation/AnnotationSetImpl.java
@@ -186,16 +186,18 @@ public class AnnotationSetImpl extends AbstractSet<Annotation> implements
   @Override
   public void clear() {
 
-    annotsById.values().forEach(annotation -> fireAnnotationRemoved(new AnnotationSetEvent(AnnotationSetImpl.this,
-            AnnotationSetEvent.ANNOTATION_REMOVED, getDocument(),
-            annotation)));
-    
+    List<Annotation> annotations = new ArrayList<>(annotsById.values());
+
     //reset all the indexes to be sure everything has been cleared correctly
     annotsById.clear();
     nodesByOffset = null;
     annotsByStartNode = null;
     annotsByType = null;
     longestAnnot = 0l;
+
+    annotations.forEach(annotation -> fireAnnotationRemoved(new AnnotationSetEvent(AnnotationSetImpl.this,
+            AnnotationSetEvent.ANNOTATION_REMOVED, getDocument(),
+            annotation)));
   }
 
   /**


### PR DESCRIPTION
No need to delete all annotations one by one in three collections when they are all cleaned in the end.
Event generating can be done outside the iterator.